### PR TITLE
잘못된 도메인 정보 바로잡기

### DIFF
--- a/fastcampus-project-spingboard/src/test/java/com/fastcampus/projectspingboard/repository/JpaRepositoryTest.java
+++ b/fastcampus-project-spingboard/src/test/java/com/fastcampus/projectspingboard/repository/JpaRepositoryTest.java
@@ -49,7 +49,7 @@ class JpaRepositoryTest {
     void givenTestData_whenInserting_thenWorksFine(){
         //given
         long previousCount = articleRepository.count();
-        UserAccount userAccount = userAccountRepository.save(UserAccount.of("uno", "pw", null, null, null));
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("new tester", "passwoed", null, null, null));
         Article article = Article.of(userAccount, "new article", "new content", "#spring");
         //when
         //Article savedArticle = articleRepository.save(Article.of("new article", "new content", "#spring"));


### PR DESCRIPTION
userAccount' 화원 계정의 userId는 회원 id 이므로 유니크해야 하는데 해당 속성이 빠져있다.
email의 유니크 키로 설정하였다.