### PR TITLE
헤로쿠에 배포하기 - DB변경 : ClearDB -> JawsDB

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,7 +41,6 @@ spring:
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always
 
-
 #---
 #
 #spring:


### PR DESCRIPTION
ClaerDB는 기본 버전이 5.6으로 낮기 때문에 문제가 발생
JawsDB를 찾아냄 기본 버전 8.0 이를 이용에 환경변수를 다시 잡음.

'5.6'버전에선 article_comment.content 인덱스 사이즈가 너무 큼